### PR TITLE
Fix AV error of the global variable finalization

### DIFF
--- a/src/Python.Utils.pas
+++ b/src/Python.Utils.pas
@@ -1479,7 +1479,7 @@ initialization
 
 finalization
   if g_MyPyEngine <> nil then
-     g_MyPyEngine.Free;
+     FreeAndNil(g_MyPyEngine);
 
 
 end.


### PR DESCRIPTION
since the g_MyPyEngine global variable is used in other modules, including Python4Delphi's visual components, it is impossible to guarantee the correct finalization sequence and that it will be deallocated correctly